### PR TITLE
pin-project-lite needs Rust 1.37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ matrix:
 
     # Test compatibility
     #
-    # 1.21.0 is the oldest supported version of Rust. This value should NOT be
+    # 1.37.0 is the oldest supported version of Rust. This value should NOT be
     # changed without prior discussion.
     #
     # This build also deploys docs
     - os: linux
-      rust: 1.31.0
+      rust: 1.37.0
       before_script:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ matrix:
 
     # Test compatibility
     #
-    # 1.37.0 is the oldest supported version of Rust. This value should NOT be
+    # 1.39.0 is the oldest supported version of Rust. This value should NOT be
     # changed without prior discussion.
     #
     # This build also deploys docs
     - os: linux
-      rust: 1.37.0
+      rust: 1.39.0
       before_script:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:


### PR DESCRIPTION
This uses tokio 0.2, which needs [pin-project-lite](https://crates.io/crates/pin-project-lite/0.1.1) at least version 0.1.1, which needs Rust 1.37.

... and as it turns out the tokio bytes work needs 1.39. See https://github.com/tokio-rs/bytes/issues/323